### PR TITLE
The override in extendClass wasn't defaulting to true

### DIFF
--- a/my.class.js
+++ b/my.class.js
@@ -55,6 +55,7 @@
   // @method my.extendClass
   // @params Class:function, extension:Object, ?override:boolean=true
   var extendClass = my.extendClass = function (Class, extension, override) {
+    if(typeof override !== false){override = true;}
     if (extension.STATIC) {
       extend(Class, extension.STATIC, override);
       delete extension.STATIC;


### PR DESCRIPTION
The examples given were not working until I added this line, or changed the last extend() call in Class to 
extend(Class,body,true)
